### PR TITLE
Updated gt16CoalErr example priors and error descriptions

### DIFF
--- a/doc/distributions/GT16ErrorModel.md
+++ b/doc/distributions/GT16ErrorModel.md
@@ -3,11 +3,11 @@ GT16ErrorModel distribution
 GT16ErrorModel(Double **epsilon**, Double **delta**, Alignment **alignment**)
 -----------------------------------------------------------------------------
 
-An error model distribution on an phased genotype alignment.
+An error model distribution on a phased genotype alignment.
 
 ### Parameters
 
-- Double **epsilon** - the sequencing/amplification error rate.
+- Double **epsilon** - the sequencing and amplification error probability.
 - Double **delta** - the allelic drop out probability.
 - Alignment **alignment** - the genotype alignment.
 

--- a/examples/gt16CoalErrModel.lphy
+++ b/examples/gt16CoalErrModel.lphy
@@ -4,7 +4,7 @@
 rates ~ Dirichlet(conc=[1.0, 2.0, 1.0, 1.0, 2.0, 1.0]);
 Q = gt16(freq=π, rates=rates); // construct the GT16 instantaneous rate matrix
 A ~ PhyloCTMC(L=200, Q=Q, tree=ψ, dataType=phasedGenotype());
-delta ~ LogNormal(meanlog=-2.3, sdlog=1.25);
-epsilon ~ LogNormal(meanlog=-2.3, sdlog=1.25);
+epsilon ~ Beta(alpha=2, beta=18);
+delta ~ Beta(alpha=5, beta=15);
 E ~ GT16ErrorModel(delta=delta, epsilon=epsilon, alignment=A);
-//D = unphase(E);
+// D = unphase(E);

--- a/src/lphy/evolution/alignment/GT16ErrorModel.java
+++ b/src/lphy/evolution/alignment/GT16ErrorModel.java
@@ -24,7 +24,7 @@ public class GT16ErrorModel implements GenerativeDistribution<Alignment> {
 
     RandomGenerator random;
 
-    public GT16ErrorModel(@ParameterInfo(name = epsilonParamName, description = "the sequencing/amplification error rate.") Value<Double> epsilon,
+    public GT16ErrorModel(@ParameterInfo(name = epsilonParamName, description = "the sequencing and amplification error probability.") Value<Double> epsilon,
                           @ParameterInfo(name = deltaParamName, description = "the allelic drop out probability.") Value<Double> delta,
                           @ParameterInfo(name = alignmentParamName, description = "the genotype alignment.") Value<Alignment> alignment) {
 


### PR DESCRIPTION
Changed gt16CoalErrModel.lphy example to use Beta priors for error probabilities instead of LogNormal.
gt16ErrorModel descriptions have also been updated to show that these parameters are probabilities.
```
epsilon ~ Beta(alpha=2, beta=18);
delta ~ Beta(alpha=5, beta=15);
```