### PR TITLE
Order variable log values to match table header order

### DIFF
--- a/lphy-studio/src/main/java/lphystudio/core/logger/VariableTextArea.java
+++ b/lphy-studio/src/main/java/lphystudio/core/logger/VariableTextArea.java
@@ -79,7 +79,7 @@ public class VariableTextArea extends JTextArea implements SimulatorListener {
 //            builder.append(sample+"");
                 builder.append(rowNames.get(sample));
 
-                for (String valId : formattedValuesById.keySet()) {
+                for (String valId : headers) {
 
                     List<Double> formattedValues = formattedValuesById.get(valId);
 


### PR DESCRIPTION
Changes the order of variables logged for each sample so that the variable log headers match the appropriate column values.