### PR TITLE
Update Logger logic to allow logging values more efficiently

### DIFF
--- a/lphy-base/src/main/java/lphy/base/evolution/alignment/Alignment.java
+++ b/lphy-base/src/main/java/lphy/base/evolution/alignment/Alignment.java
@@ -125,6 +125,12 @@ public interface Alignment extends Taxa, TaxaCharacterMatrix<Integer> {
         return Objects.requireNonNull(getSequenceType()).getCanonicalStates();
     }
 
+    default String getCharacter(int taxonIndex, int position) {
+        int stateInt = getState(taxonIndex, position);
+        State state = getSequenceType().getState(stateInt);
+        return state.toString();
+    }
+
     /**
      * @param taxonIndex   the taxon index
      * @return   the sequence in a string of a taxon given by index

--- a/lphy-base/src/main/java/lphy/base/evolution/alignment/FastaAlignment.java
+++ b/lphy-base/src/main/java/lphy/base/evolution/alignment/FastaAlignment.java
@@ -5,6 +5,8 @@ import lphy.base.evolution.Taxon;
 import lphy.core.logger.LoggerUtils;
 import lphy.core.logger.TextFileFormatted;
 
+import java.io.BufferedWriter;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +26,7 @@ public class FastaAlignment implements Alignment, TextFileFormatted {
     public List<String> getTextForFile() {
         List<String> lines = new ArrayList<>();
 
-        for (int i=0; i < ntaxa(); i++) {
+        for (int i = 0; i < ntaxa(); i++) {
             try {
                 String taxonName = this.getTaxonName(i);
                 lines.add(">" + taxonName);
@@ -37,6 +39,25 @@ public class FastaAlignment implements Alignment, TextFileFormatted {
         }
 
         return lines;
+    }
+
+    /**
+     * writes alignment character by character
+     * @param writer buffered writer to write output to
+     */
+    @Override
+    public void writeToFile(BufferedWriter writer) {
+        for (int i = 0; i < ntaxa(); i++) {
+            try {
+                writer.write(">" + this.getTaxonName(i) + "\n");
+                for (int j = 0; j < nchar(); j++) {
+                    writer.write(this.getCharacter(i, j));
+                }
+                writer.write("\n");
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
     }
 
     @Override

--- a/lphy-base/src/main/java/lphy/base/logger/NexusAlignmentFormatter.java
+++ b/lphy-base/src/main/java/lphy/base/logger/NexusAlignmentFormatter.java
@@ -5,6 +5,9 @@ import lphy.base.parser.nexus.NexusUtils;
 import lphy.core.logger.ValueFormatter;
 import lphy.core.model.Symbols;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+
 public class NexusAlignmentFormatter implements ValueFormatter<SimpleAlignment> {
 
     SimpleAlignment simpleAlignment;
@@ -16,6 +19,15 @@ public class NexusAlignmentFormatter implements ValueFormatter<SimpleAlignment> 
     public NexusAlignmentFormatter(String valueID, SimpleAlignment simpleAlignment) {
         this.valueID = Symbols.getCanonical(valueID);
         this.simpleAlignment = simpleAlignment;
+    }
+
+    @Override
+    public void writeToFile(BufferedWriter writer, SimpleAlignment value) {
+        try {
+            writer.write(format(value));
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
     }
 
     @Override

--- a/lphy-base/src/main/java/lphy/base/logger/NexusTreeFormatter.java
+++ b/lphy-base/src/main/java/lphy/base/logger/NexusTreeFormatter.java
@@ -5,6 +5,9 @@ import lphy.base.parser.nexus.NexusUtils;
 import lphy.core.logger.ValueFormatter;
 import lphy.core.model.Symbols;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+
 public class NexusTreeFormatter implements ValueFormatter<TimeTree> {
 
     String valueID;
@@ -16,6 +19,16 @@ public class NexusTreeFormatter implements ValueFormatter<TimeTree> {
     public NexusTreeFormatter(String valueID, TimeTree tree) {
         this.valueID = Symbols.getCanonical(valueID);
         this.tree = tree;
+    }
+
+    @Override
+    public void writeToFile(BufferedWriter writer, TimeTree value) {
+        // TODO: write trees
+        try {
+            writer.write(format(value));
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
     }
 
     @Override

--- a/lphy-base/src/main/java/lphy/base/logger/VCFFormatter.java
+++ b/lphy-base/src/main/java/lphy/base/logger/VCFFormatter.java
@@ -5,6 +5,9 @@ import lphy.base.evolution.datatype.Variant;
 import lphy.core.logger.ValueFormatter;
 import lphy.core.model.Symbols;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+
 public class VCFFormatter implements ValueFormatter<Variant[]> {
     String valueID;
     Variant[] variants;
@@ -12,6 +15,15 @@ public class VCFFormatter implements ValueFormatter<Variant[]> {
     public VCFFormatter(String valueID, Variant[] variants) {
         this.valueID = Symbols.getCanonical(valueID);
         this.variants = variants;
+    }
+
+    @Override
+    public void writeToFile(BufferedWriter writer, Variant[] value) {
+        try {
+            writer.write(format(value));
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
     }
 
     @Override

--- a/lphy-studio/src/main/java/lphystudio/app/LinguaPhyloStudio.java
+++ b/lphy-studio/src/main/java/lphystudio/app/LinguaPhyloStudio.java
@@ -1,6 +1,7 @@
 package lphystudio.app;
 
 import lphy.core.codebuilder.CanonicalCodeBuilder;
+import lphy.core.logger.FileLoggerListener;
 import lphy.core.logger.LoggerUtils;
 import lphy.core.logger.TextFileFormatted;
 import lphy.core.logger.ValueFileLoggerListener;
@@ -298,7 +299,7 @@ public class LinguaPhyloStudio {
 
                     // TODO: Cannot specify to call which formatter in the core, as Nexus formatter is in the base,
                     // so call ValueFileLoggerListener instead, however the alignment will be simulated again.
-                    ValueFileLoggerListener fileLoggerListener = new ValueFileLoggerListener();
+                    FileLoggerListener fileLoggerListener = new FileLoggerListener();
                     // set alignment directory
                     fileLoggerListener.setOutputDir(selectedDir.getAbsolutePath());
                     LoggerUtils.log.info("Save the alignments to: " + selectedDir.getAbsolutePath());

--- a/lphy-studio/src/main/java/lphystudio/core/logger/AlignmentTextFormatter.java
+++ b/lphy-studio/src/main/java/lphystudio/core/logger/AlignmentTextFormatter.java
@@ -4,21 +4,31 @@ import lphy.base.evolution.alignment.SimpleAlignment;
 import lphy.core.logger.ValueFormatter;
 import lphy.core.model.Symbols;
 
+import java.io.BufferedWriter;
+
 public class AlignmentTextFormatter implements ValueFormatter<SimpleAlignment> {
 
     SimpleAlignment simpleAlignment;
     String valueID;
-//    boolean isClamped;
-
-//    public AlignmentTextFormatter(String valueID, SimpleAlignment simpleAlignment, Boolean isClamped) {
-//        this.valueID = Symbols.getCanonical(valueID);
-//        this.simpleAlignment = simpleAlignment;
-//        this.isClamped = isClamped;
-//    }
 
     public AlignmentTextFormatter(String valueID, SimpleAlignment simpleAlignment) {
         this.valueID = Symbols.getCanonical(valueID);
         this.simpleAlignment = simpleAlignment;
+    }
+
+    @Override
+    public void writeToFile(BufferedWriter writer, SimpleAlignment simpleAlignment) {
+        for (int i = 0; i < simpleAlignment.ntaxa(); i++) {
+            try {
+                writer.write(">" + simpleAlignment.getTaxonName(i) + "\n");
+                for (int j = 0; j < simpleAlignment.nchar(); j++) {
+                    writer.write(simpleAlignment.getCharacter(i, j));
+                }
+                writer.write("\n");
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
     }
 
     @Override

--- a/lphy-studio/src/main/java/lphystudio/core/logger/TreeTextFormatter.java
+++ b/lphy-studio/src/main/java/lphystudio/core/logger/TreeTextFormatter.java
@@ -4,6 +4,9 @@ import lphy.base.evolution.tree.TimeTree;
 import lphy.core.logger.ValueFormatter;
 import lphy.core.model.Symbols;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+
 public class TreeTextFormatter implements ValueFormatter<TimeTree> {
 
     String valueID;
@@ -15,6 +18,15 @@ public class TreeTextFormatter implements ValueFormatter<TimeTree> {
     public TreeTextFormatter(String valueID, TimeTree tree) {
         this.valueID = Symbols.getCanonical(valueID);
         this.tree = tree;
+    }
+
+    @Override
+    public void writeToFile(BufferedWriter writer, TimeTree value) {
+        try {
+            writer.write(format(value));
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
     }
 
     @Override

--- a/lphy/src/main/java/lphy/core/logger/Array2DElementFormatter.java
+++ b/lphy/src/main/java/lphy/core/logger/Array2DElementFormatter.java
@@ -3,6 +3,8 @@ package lphy.core.logger;
 import lphy.core.model.Symbols;
 import lphy.core.vectorization.VectorUtils;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -39,6 +41,15 @@ public class Array2DElementFormatter<T> implements ValueFormatter<T[][]> {
     public static String getElementValueId(String arrayValueID, int rowIndex, int colIndex) {
         return Symbols.getCanonical(arrayValueID) + VectorUtils.INDEX_SEPARATOR + rowIndex +
                 VectorUtils.INDEX_SEPARATOR + colIndex;
+    }
+
+    @Override
+    public void writeToFile(BufferedWriter writer, T[][] value) {
+        try {
+            writer.write(format(value));
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
     }
 
     @Override

--- a/lphy/src/main/java/lphy/core/logger/ArrayElementFormatter.java
+++ b/lphy/src/main/java/lphy/core/logger/ArrayElementFormatter.java
@@ -3,6 +3,9 @@ package lphy.core.logger;
 import lphy.core.model.Symbols;
 import lphy.core.vectorization.VectorUtils;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+
 /**
  * The 1d array case for the implementation of ValueFormatter.
  *
@@ -33,6 +36,15 @@ public class ArrayElementFormatter<T> implements ValueFormatter<T[]> {
 
     public static String getElementValueId(String arrayValueID, int arrayIndex) {
         return Symbols.getCanonical(arrayValueID) + VectorUtils.INDEX_SEPARATOR + arrayIndex;
+    }
+
+    @Override
+    public void writeToFile(BufferedWriter writer, T[] value) {
+        try {
+            writer.write(format(value));
+        } catch(IOException ex) {
+            ex.printStackTrace();
+        }
     }
 
     @Override

--- a/lphy/src/main/java/lphy/core/logger/FileLoggerListener.java
+++ b/lphy/src/main/java/lphy/core/logger/FileLoggerListener.java
@@ -1,0 +1,202 @@
+package lphy.core.logger;
+
+import lphy.core.io.FileConfig;
+import lphy.core.io.OutputSystem;
+import lphy.core.model.Value;
+import lphy.core.simulator.SimulatorListener;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static lphy.core.spi.LoaderManager.valueFormatResolver;
+
+public class FileLoggerListener implements SimulatorListener {
+
+    FileConfig fileConfig;
+    BufferedWriter writer;
+
+    // map file absolute paths to buffered writer
+    Map<String, BufferedWriter> writerMap;
+
+    public final String DELIMITER = "\t";
+
+    @Override
+    public void start(Object... configs) {
+        // TODO: tidy up this code (copied from previous version)
+        if (configs.length == 1 && configs[0] instanceof FileConfig fileConfig) {
+            this.fileConfig = fileConfig;
+        } else if (configs.length == 2 && configs[0] instanceof Integer numReplicates &&
+                configs[1] instanceof String filePrefix) {
+            // store numReplicates, filePrefix
+            fileConfig = new FileConfig(numReplicates, filePrefix);
+        } else if (configs.length == 3 && configs[0] instanceof Integer numReplicates &&
+                configs[1] instanceof File lphyFile &&
+                configs[2] instanceof Long seed ) {
+            try {
+                fileConfig = new FileConfig(numReplicates, lphyFile, seed);
+            } catch (IOException e) {
+                LoggerUtils.log.severe(e.getMessage());
+                throw new RuntimeException(e);
+            }
+        } else {
+            throw new UnsupportedOperationException("Unsupported configs to start in ValueFileLoggerListener : " + Arrays.toString(configs) + " !");
+        }
+    }
+
+    @Override
+    public void replicate(int index, List<Value> values) {
+        for (int i = 0; i < values.size(); i++) {
+            Value value = values.get(i);
+            Class type = value.getType();
+
+            if (TextFileFormatted.class.isAssignableFrom(type)) {
+                // extension formatter (one file per type?)
+                TextFileFormatted fileFormatted = (TextFileFormatted) value.value();
+
+                String fileExtension = fileFormatted.getFileType();
+                String canonicalId = value.getCanonicalId();
+
+                String fileName = FileConfig.getOutFileName(canonicalId, index,
+                        fileConfig.getNumReplicates(), fileConfig.getFilePrefix(), fileExtension);
+                File file = OutputSystem.getOutputFile(fileName, true);
+
+                try {
+                    file.createNewFile(); // create file
+                    writer = new BufferedWriter(new FileWriter(file));
+                    fileFormatted.writeToFile(writer); // write output to file
+                    writer.close(); // close file
+                } catch (IOException ex) {
+                    ex.printStackTrace();
+                }
+
+            } else {
+                // else default lphy core formatters
+                List<ValueFormatter> formatters = valueFormatResolver.getFormatter(value);
+                boolean firstCol = true;
+                for (int j = 0; j < formatters.size(); j++) {
+                    ValueFormatter formatter = formatters.get(j);
+                    if (formatter == null) {
+                        // no formatter available
+                        LoggerUtils.log.warning(String.format("No formatter for %s of type %s", value.getId(), value.getType()));
+                    } else if (formatter.getMode() == ValueFormatter.Mode.VALUE_PER_FILE) {
+                        // one value per file (alignment file)
+                        File file = getFile(formatter, index);
+                        try {
+                            file.createNewFile(); // create file
+                            writer = new BufferedWriter(new FileWriter(file));
+                            formatter.writeToFile(writer, value); // write values to file
+                            writer.close(); // close file
+                        } catch (IOException ex) {
+                            ex.printStackTrace();
+                        }
+                    } else if (formatter.getMode() == ValueFormatter.Mode.VALUE_PER_LINE) {
+                        // one value per line (tree file)
+                        File file = getFile(formatter, index);
+                        try {
+                            if (index == 0) {
+                                file.createNewFile(); // create file
+                                String header = formatter.header(); // file header
+                                writer = new BufferedWriter(new FileWriter(file));
+                                writer.write(header + "\n");
+                                writerMap.put(file.getAbsolutePath(), writer);
+                            } else {
+                                writer = writerMap.get(file.getAbsolutePath());
+                            }
+
+                            if (index < fileConfig.numReplicates - 1) {
+                                // write body
+                                String rowName = formatter.getRowName(index);
+                                writer.write(rowName); // row index
+                                formatter.writeToFile(writer, value); // write values
+                                writer.write("\n");
+                            } else if (index == fileConfig.numReplicates - 1) {
+                                // write footer
+                                String footer = formatter.footer();
+                                writer.write(footer);
+                                writer.write("\n");
+                                writer.close(); // close file at last replicate
+                            }
+
+                        } catch (IOException ex) {
+                            ex.printStackTrace();
+                        }
+                    } else if (formatter.getMode() == ValueFormatter.Mode.VALUE_PER_CELL) {
+                        // default log file
+                        // column headers (Sample, var1, var1, ...)
+                        String rowName = formatter.getRowName(index);
+                        File file = getFile(formatter, index);
+                        if (index == 0) {
+                            String header = formatter.header();
+                            String styledHeader = "Sample" + DELIMITER + header;
+                            try {
+                                if (firstCol) {
+                                    file.createNewFile(); // create file
+                                    writer = new BufferedWriter(new FileWriter(file));
+                                    writerMap.put(file.getAbsolutePath(), writer);
+                                    writer.write(styledHeader); // header
+                                    // replicate number
+                                    writer.write(rowName + DELIMITER);
+                                    // value
+                                    formatter.writeToFile(writer, value);
+                                    firstCol = false;
+                                } else {
+                                    writer = writerMap.get(file.getAbsolutePath());
+                                    writer.write(DELIMITER);
+                                    formatter.writeToFile(writer, value);
+                                }
+
+                            } catch (IOException ex) {
+                                ex.printStackTrace();
+                            }
+                        } else {
+                            try {
+                                // replicates do not need to write header
+                                writer = writerMap.get(file.getAbsolutePath());
+                                if (firstCol) {
+                                    writer.write(rowName + DELIMITER);
+                                    formatter.writeToFile(writer, value);
+                                    firstCol = false;
+                                } else {
+                                    writer.write(DELIMITER);
+                                    formatter.writeToFile(writer, value);
+                                }
+                            } catch (IOException ex) {
+                                ex.printStackTrace();
+                            }
+
+                        }
+
+                    }
+
+                }
+            }
+
+        }
+    }
+
+    private File getFile(ValueFormatter formatter, int index) {
+        String filePrefix = fileConfig.getFilePrefix();
+        int numReplicates = fileConfig.getNumReplicates();
+        String fileExtension = formatter.getExtension();
+        String id = formatter.getValueID();
+        String fileName = FileConfig.getOutFileName(id, index, numReplicates, filePrefix, fileExtension);
+        return new File(fileName);
+    }
+
+    @Override
+    public void complete() {
+        try {
+            // close all remaining buffered writers
+            for (BufferedWriter w : writerMap.values()) {
+                w.close();
+            }
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+}

--- a/lphy/src/main/java/lphy/core/logger/TextFileFormatted.java
+++ b/lphy/src/main/java/lphy/core/logger/TextFileFormatted.java
@@ -2,6 +2,8 @@ package lphy.core.logger;
 
 import lphy.core.model.Value;
 
+import java.io.BufferedWriter;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -13,7 +15,13 @@ import java.util.List;
  */
 public interface TextFileFormatted {
 
+    /*
+       To be replaced with writeToFile() method below
+     */
+    @Deprecated
     List<String> getTextForFile();
+
+    void writeToFile(BufferedWriter writer);
 
     String getFileType();
 

--- a/lphy/src/main/java/lphy/core/logger/ValueFormatter.java
+++ b/lphy/src/main/java/lphy/core/logger/ValueFormatter.java
@@ -3,6 +3,10 @@ package lphy.core.logger;
 import lphy.core.model.Symbols;
 import lphy.core.model.Value;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+
 /**
  * Note: this cannot be extended by lphy extension developers,
  *       please use {@link TextFileFormatted}.
@@ -24,6 +28,8 @@ public interface ValueFormatter<T> {
         // The value of each replicate should be logged into separate rows as a column in a single container.
         VALUE_PER_CELL
     }
+
+    public void writeToFile(BufferedWriter writer, T value);
 
     default String getExtension() {
         return ".log";
@@ -81,6 +87,15 @@ public interface ValueFormatter<T> {
         }
 
         @Override
+        public void writeToFile(BufferedWriter writer, T value) {
+            try {
+                writer.write(value.toString());
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+
+        @Override
         public Class<T> getDataTypeClass() {
             // getTypeParameters()[0] retrieves the type T
             return (Class<T>) getClass().getTypeParameters()[0].getClass();
@@ -91,7 +106,6 @@ public interface ValueFormatter<T> {
             this.value = value;
             return ValueFormatter.super.format(value);
         }
-
         @Override
         public String getValueID() {
             return valueID;
@@ -101,19 +115,5 @@ public interface ValueFormatter<T> {
             return value;
         }
     }
-
-    //TODO this feature requires to return Number not String, perhaps it should be in parser.
-    // Currently it is implemented in RandomNumberLoggerListener
-//    class BooleanValueFormatter extends ValueFormatter.Base<Boolean> {
-//
-//        public BooleanValueFormatter(String valueID, Boolean value) {
-//            super(valueID, value);
-//        }
-//
-//        @Override
-//        public String format(Boolean value) {
-//            return value ? "1.0" : "0.0";
-//        }
-//    }
 
 }

--- a/lphy/src/main/java/lphy/core/logger/ValueFormatter.java
+++ b/lphy/src/main/java/lphy/core/logger/ValueFormatter.java
@@ -89,7 +89,7 @@ public interface ValueFormatter<T> {
         @Override
         public void writeToFile(BufferedWriter writer, T value) {
             try {
-                writer.write(value.toString());
+                writer.write(format(value));
             } catch (IOException ex) {
                 ex.printStackTrace();
             }

--- a/lphy/src/main/java/lphy/core/simulator/NamedRandomValueSimulator.java
+++ b/lphy/src/main/java/lphy/core/simulator/NamedRandomValueSimulator.java
@@ -1,6 +1,7 @@
 package lphy.core.simulator;
 
 import lphy.core.io.FileConfig;
+import lphy.core.logger.FileLoggerListener;
 import lphy.core.logger.ValueFileLoggerListener;
 import lphy.core.model.RandomVariable;
 import lphy.core.model.Value;
@@ -29,7 +30,8 @@ public class NamedRandomValueSimulator {
     protected Sampler sampler;
 
     public NamedRandomValueSimulator() {
-        this(new ValueFileLoggerListener());
+        // calls LoggerListener code
+        this(new FileLoggerListener());
     }
 
     public NamedRandomValueSimulator(SimulatorListener simulatorListener) {


### PR DESCRIPTION
SLPhy now uses `FileLoggerListener` by default rather than `ValueFileLoggerListener`. 

For extensions with custom loggers please extend `lphy.core.logger.TextFileFormatted` and implement the method `writeToFile(BufferedWriter writer);`